### PR TITLE
Added Topic Sort Pin Posts On Top Logic (DO NOT ACCEPT)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nodebb-theme-quickstart"]
+	path = nodebb-theme-quickstart
+	url = git@github.com:sschauk/nodebb-theme-quickstart.git

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -267,21 +267,34 @@ define('forum/topic/postTools', [
 			openChat($(this));
 		});
 
-		// This is added logic that is done in order to pin a post when we click watched
-		// THis should be changed to be done when we click on the pin button when implemented.
+		// This code block is added to pinning or unpinning a post when we click the watched button,
+		// but this should be updated to trigger when the actual pin button is implemented.
+		// Listen for a click event on the button within the post container.
+		// Note: "component='topic/watched'" is used to identify the watched button.
 		postContainer.on('click', '[component="topic/watched"]', function () {
+			
+			// Get the topic tid of post.
 			const tid = $(this).closest('[data-tid]').data('tid');
+			
+			// Determine whether the post is currently pinned.
 			const isPinned = $(this).hasClass('pinned');
 			
+			// Emit a 'topics.pin' event to the server to toggle the pin state of the topic.
 			socket.emit('topics.pin', { tid: tid, pin: !isPinned }, function (err) {
+				
+				// Error message for privaledges.
 				if (err) {
 					app.alertError(err.message);
 				} else {
+					// This visually updates the post to reflect its pinned or unpinned state.
 					$(this).toggleClass('pinned', !isPinned);
+					
+					// Success message
 					app.alertSuccess('Topic ' + (!isPinned ? 'pinned' : 'unpinned') + ' successfully');
 				}
 			}.bind(this));
 		});
+
 		
 	}
 

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -266,6 +266,23 @@ define('forum/topic/postTools', [
 		postContainer.on('click', '[component="post/chat"]', function () {
 			openChat($(this));
 		});
+
+		// This is added logic that is done in order to pin a post when we click watched
+		// THis should be changed to be done when we click on the pin button when implemented.
+		postContainer.on('click', '[component="topic/watched"]', function () {
+			const tid = $(this).closest('[data-tid]').data('tid');
+			const isPinned = $(this).hasClass('pinned');
+			
+			socket.emit('topics.pin', { tid: tid, pin: !isPinned }, function (err) {
+				if (err) {
+					app.alertError(err.message);
+				} else {
+					$(this).toggleClass('pinned', !isPinned);
+					app.alertSuccess('Topic ' + (!isPinned ? 'pinned' : 'unpinned') + ' successfully');
+				}
+			}.bind(this));
+		});
+		
 	}
 
 	async function onReplyClicked(button, tid) {

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -30,12 +30,17 @@ define('forum/topic/posts', [
 		data.loggedIn = !!app.user.uid;
 		data.privileges = ajaxify.data.privileges;
 
-		// if not a scheduled topic, prevent timeago in future by setting timestamp to 1 sec behind now
-		data.posts[0].timestamp = data.posts[0].topic.scheduled ? data.posts[0].timestamp : Date.now() - 1000;
+		// If the topic is not scheduled, adjust the timestamp to avoid future dates.
+		// This ensures that the post appears as if it was created slightly in the past.
+		// The timestamp is set 1 second behind the current time to prevent the timeago 
+		// Plugin from showing it as being in the future.
+		data.posts[0].timestamp = data.posts[0].topic.scheduled ? data.posts[0].timestamp : Date.now() - 1;
+		// Convert the updated timestamp into ISO format to be used for display in the UI.
 		data.posts[0].timestampISO = utils.toISOString(data.posts[0].timestamp);
 
-		// This next code block is added for making it 
-		const isPinned = data.posts[0].pinned;
+		// This block was added to manage the pin/unpin functionality for the topic.
+		// We extract the current 'pinned' state of the post and tid to send the 
+		// appropriate pin/unpin action via socket. 
 		const tid = data.posts[0].tid;
 		socket.emit('topics.pin', { tid: tid, pin: !isPinned }, function (err) {
 			if (err) {

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -34,6 +34,17 @@ define('forum/topic/posts', [
 		data.posts[0].timestamp = data.posts[0].topic.scheduled ? data.posts[0].timestamp : Date.now() - 1000;
 		data.posts[0].timestampISO = utils.toISOString(data.posts[0].timestamp);
 
+		// This next code block is added for making it 
+		const isPinned = data.posts[0].pinned;
+		const tid = data.posts[0].tid;
+		socket.emit('topics.pin', { tid: tid, pin: !isPinned }, function (err) {
+			if (err) {
+				app.alertError(err.message);
+			} else {
+				app.alertSuccess('Topic ' + (!isPinned ? 'pinned' : 'unpinned') + ' successfully');
+			}
+		});
+
 		Posts.modifyPostsByPrivileges(data.posts);
 
 		updatePostCounts(data.posts);

--- a/src/topics/pin.js
+++ b/src/topics/pin.js
@@ -11,31 +11,33 @@ const Pin = {};
 
 // Toggle Pin/Unpin a topic
 Pin.togglePin = async function (tid, uid, pin) {
-    // Fetch topic data
-    const topicData = await Topics.getTopicData(tid);
+    const topicData = await topics.getTopicData(tid);  // Use lowercase 'topics'
     if (!topicData) {
         throw new Error('[[error:no-topic]]');
     }
 
-    if (topic.scheduled) {
+    if (topicData.scheduled) {
         throw new Error('[[error:cant-pin-scheduled]]');
     }
 
-    if (uid !== 'system' && !await privileges.topics.isAdminOrMod(tid, uid)) {
+    const isAdminOrMod = uid === 'system' || await privileges.topics.isAdminOrMod(tid, uid);
+    if (!isAdminOrMod) {
         throw new Error('[[error:no-privileges]]');
     }
 
-    if (pin && topic.pinned) {
+    if (pin && topicData.pinned) {
         throw new Error('[[error:topic-already-pinned]]');
-    } else if (!pin && !topic.pinned) {
+    } else if (!pin && !topicData.pinned) {
         throw new Error('[[error:topic-not-pinned]]');
     }
 
     // Update pin status in the database
     const promises = [
-        Topics.setTopicField(tid, 'pinned', pin ? 1 : 0),
-		Topics.events.log(tid, { type: pin ? 'pin' : 'unpin', uid }),
+        topics.setTopicField(tid, 'pinned', pin ? 1 : 0),
+        event.emit(pin ? 'topic.pinned' : 'topic.unpinned', { tid, uid }),
+        plugins.hooks.fire('action:topic.pin', { topic: _.clone(topicData), uid }),
     ];
+
     if (pin) {
         promises.push(db.sortedSetAdd(`cid:${topicData.cid}:tids:pinned`, Date.now(), tid));
         promises.push(db.sortedSetsRemove([
@@ -47,7 +49,7 @@ Pin.togglePin = async function (tid, uid, pin) {
         ], tid));
     } else {
         promises.push(db.sortedSetRemove(`cid:${topicData.cid}:tids:pinned`, tid));
-        promises.push(Topics.deleteTopicField(tid, 'pinExpiry'));
+        promises.push(topics.deleteTopicField(tid, 'pinExpiry'));
         promises.push(db.sortedSetAddBulk([
             [`cid:${topicData.cid}:tids`, topicData.lastposttime, tid],
             [`cid:${topicData.cid}:tids:create`, topicData.timestamp, tid],
@@ -59,11 +61,7 @@ Pin.togglePin = async function (tid, uid, pin) {
         topicData.pinExpiryISO = undefined;
     }
 
-    const results = await Promise.all(promises);
-
-    // Emit appropriate event
-    event.emit(pin ? 'topic.pinned' : 'topic.unpinned', { tid, uid });
-    plugins.hooks.fire('action:topic.pin', { topic: _.clone(topicData), uid });
+    await Promise.all(promises);
 
     return { tid, pinned: pin };
 };
@@ -76,80 +74,6 @@ Pin.pin = async function (tid, uid) {
 // Unpin a topic
 Pin.unpin = async function (tid, uid) {
     return await Pin.togglePin(tid, uid, false);
-};
-
-// Set pin expiry for a topic
-Pin.setPinExpiry = async function (tid, expiry, uid) {
-    // Validate expiry date
-    if (isNaN(parseInt(expiry, 10)) || expiry <= Date.now()) {
-        throw new Error('[[error:invalid-data]]');
-    }
-
-    // Check privileges
-    const topic = await topics.getTopicFields(tid, ['cid', 'uid']);
-    const isAdminOrMod = await privileges.categories.isAdminOrMod(topic.cid, uid);
-    if (!isAdminOrMod) {
-        throw new Error('[[error:no-privileges]]');
-    }
-
-    // Set pin expiry in the database
-    await topics.setTopicField(tid, 'pinExpiry', expiry);
-    plugins.hooks.fire('action:topic.setPinExpiry', { topic, uid, expiry });
-
-    return { tid, expiry };
-};
-
-// Check and expire pins
-Pin.checkPinExpiry = async function (tids) {
-    const expiryDates = await topics.getTopicsFields(tids, ['pinExpiry']);
-    const now = Date.now();
-
-    // Check and unpin topics that have expired
-    const unpinPromises = expiryDates.map(async (topicExpiry, idx) => {
-        if (topicExpiry && parseInt(topicExpiry.pinExpiry, 10) <= now) {
-            await Pin.unpin(tids[idx], 'system');
-            return null;
-        }
-        return tids[idx];
-    });
-
-    const filteredTids = (await Promise.all(unpinPromises)).filter(Boolean);
-    return filteredTids;
-};
-
-// Order pinned topics
-Pin.orderPinnedTopics = async function (uid, data) {
-    const { tid, order } = data;
-    const cid = await topics.getTopicField(tid, 'cid');
-
-    if (!cid || !tid || !utils.isNumber(order) || order < 0) {
-        throw new Error('[[error:invalid-data]]');
-    }
-
-    const isAdminOrMod = await privileges.categories.isAdminOrMod(cid, uid);
-    if (!isAdminOrMod) {
-        throw new Error('[[error:no-privileges]]');
-    }
-
-    const pinnedTids = await db.getSortedSetRange(`cid:${cid}:tids:pinned`, 0, -1);
-    const currentIndex = pinnedTids.indexOf(String(tid));
-    if (currentIndex === -1) {
-        return;
-    }
-
-    const newOrder = pinnedTids.length - order - 1;
-    // Move tid to the specified order
-    if (pinnedTids.length > 1) {
-        pinnedTids.splice(Math.max(0, newOrder), 0, pinnedTids.splice(currentIndex, 1)[0]);
-    }
-
-    await db.sortedSetAddBulk(
-        `cid:${cid}:tids:pinned`,
-        pinnedTids.map((tid, index) => index),
-        pinnedTids
-    );
-
-    return pinnedTids;
 };
 
 module.exports = Pin;

--- a/src/topics/pin.js
+++ b/src/topics/pin.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const db = require('../database');
+const topics = require('./topics');
+const privileges = require('../privileges');
+const event = require('../event');
+const utils = require('../utils');
+const plugins = require('../plugins');
+
+const Pin = {};
+
+// Toggle Pin/Unpin a topic
+Pin.togglePin = async function (tid, uid, pin) {
+    // Fetch topic data
+    const topicData = await Topics.getTopicData(tid);
+    if (!topicData) {
+        throw new Error('[[error:no-topic]]');
+    }
+
+    if (topic.scheduled) {
+        throw new Error('[[error:cant-pin-scheduled]]');
+    }
+
+    if (uid !== 'system' && !await privileges.topics.isAdminOrMod(tid, uid)) {
+        throw new Error('[[error:no-privileges]]');
+    }
+
+    if (pin && topic.pinned) {
+        throw new Error('[[error:topic-already-pinned]]');
+    } else if (!pin && !topic.pinned) {
+        throw new Error('[[error:topic-not-pinned]]');
+    }
+
+    // Update pin status in the database
+    const promises = [
+        Topics.setTopicField(tid, 'pinned', pin ? 1 : 0),
+		Topics.events.log(tid, { type: pin ? 'pin' : 'unpin', uid }),
+    ];
+    if (pin) {
+        promises.push(db.sortedSetAdd(`cid:${topicData.cid}:tids:pinned`, Date.now(), tid));
+        promises.push(db.sortedSetsRemove([
+            `cid:${topicData.cid}:tids`,
+            `cid:${topicData.cid}:tids:create`,
+            `cid:${topicData.cid}:tids:posts`,
+            `cid:${topicData.cid}:tids:votes`,
+            `cid:${topicData.cid}:tids:views`,
+        ], tid));
+    } else {
+        promises.push(db.sortedSetRemove(`cid:${topicData.cid}:tids:pinned`, tid));
+        promises.push(Topics.deleteTopicField(tid, 'pinExpiry'));
+        promises.push(db.sortedSetAddBulk([
+            [`cid:${topicData.cid}:tids`, topicData.lastposttime, tid],
+            [`cid:${topicData.cid}:tids:create`, topicData.timestamp, tid],
+            [`cid:${topicData.cid}:tids:posts`, topicData.postcount, tid],
+            [`cid:${topicData.cid}:tids:votes`, parseInt(topicData.votes, 10) || 0, tid],
+            [`cid:${topicData.cid}:tids:views`, topicData.viewcount, tid],
+        ]));
+        topicData.pinExpiry = undefined;
+        topicData.pinExpiryISO = undefined;
+    }
+
+    const results = await Promise.all(promises);
+
+    // Emit appropriate event
+    event.emit(pin ? 'topic.pinned' : 'topic.unpinned', { tid, uid });
+    plugins.hooks.fire('action:topic.pin', { topic: _.clone(topicData), uid });
+
+    return { tid, pinned: pin };
+};
+
+// Pin a topic
+Pin.pin = async function (tid, uid) {
+    return await Pin.togglePin(tid, uid, true);
+};
+
+// Unpin a topic
+Pin.unpin = async function (tid, uid) {
+    return await Pin.togglePin(tid, uid, false);
+};
+
+// Set pin expiry for a topic
+Pin.setPinExpiry = async function (tid, expiry, uid) {
+    // Validate expiry date
+    if (isNaN(parseInt(expiry, 10)) || expiry <= Date.now()) {
+        throw new Error('[[error:invalid-data]]');
+    }
+
+    // Check privileges
+    const topic = await topics.getTopicFields(tid, ['cid', 'uid']);
+    const isAdminOrMod = await privileges.categories.isAdminOrMod(topic.cid, uid);
+    if (!isAdminOrMod) {
+        throw new Error('[[error:no-privileges]]');
+    }
+
+    // Set pin expiry in the database
+    await topics.setTopicField(tid, 'pinExpiry', expiry);
+    plugins.hooks.fire('action:topic.setPinExpiry', { topic, uid, expiry });
+
+    return { tid, expiry };
+};
+
+// Check and expire pins
+Pin.checkPinExpiry = async function (tids) {
+    const expiryDates = await topics.getTopicsFields(tids, ['pinExpiry']);
+    const now = Date.now();
+
+    // Check and unpin topics that have expired
+    const unpinPromises = expiryDates.map(async (topicExpiry, idx) => {
+        if (topicExpiry && parseInt(topicExpiry.pinExpiry, 10) <= now) {
+            await Pin.unpin(tids[idx], 'system');
+            return null;
+        }
+        return tids[idx];
+    });
+
+    const filteredTids = (await Promise.all(unpinPromises)).filter(Boolean);
+    return filteredTids;
+};
+
+// Order pinned topics
+Pin.orderPinnedTopics = async function (uid, data) {
+    const { tid, order } = data;
+    const cid = await topics.getTopicField(tid, 'cid');
+
+    if (!cid || !tid || !utils.isNumber(order) || order < 0) {
+        throw new Error('[[error:invalid-data]]');
+    }
+
+    const isAdminOrMod = await privileges.categories.isAdminOrMod(cid, uid);
+    if (!isAdminOrMod) {
+        throw new Error('[[error:no-privileges]]');
+    }
+
+    const pinnedTids = await db.getSortedSetRange(`cid:${cid}:tids:pinned`, 0, -1);
+    const currentIndex = pinnedTids.indexOf(String(tid));
+    if (currentIndex === -1) {
+        return;
+    }
+
+    const newOrder = pinnedTids.length - order - 1;
+    // Move tid to the specified order
+    if (pinnedTids.length > 1) {
+        pinnedTids.splice(Math.max(0, newOrder), 0, pinnedTids.splice(currentIndex, 1)[0]);
+    }
+
+    await db.sortedSetAddBulk(
+        `cid:${cid}:tids:pinned`,
+        pinnedTids.map((tid, index) => index),
+        pinnedTids
+    );
+
+    return pinnedTids;
+};
+
+module.exports = Pin;

--- a/test/topics.js
+++ b/test/topics.js
@@ -834,7 +834,7 @@ describe('Topic\'s', () => {
 		let tid1;
 		let tid2;
 		let tid3;
-		
+
 		before(async () => {
 			async function createTopic() {
 				return (await topics.post({
@@ -851,7 +851,7 @@ describe('Topic\'s', () => {
 			await sleep(5); // Ensure different pin times
 			await topics.tools.pin(tid2, adminUid);
 		});
-	
+
 		const socketTopics = require('../src/socket.io/topics');
 	
 		it('should error with null data', (done) => {
@@ -860,7 +860,7 @@ describe('Topic\'s', () => {
 				done();
 			});
 		});
-	
+
 		it('should error with array of nulls', (done) => {
 			socketTopics.orderPinnedTopics({ uid: adminUid }, [null, null], (err) => {
 				assert.equal(err.message, '[[error:invalid-data]]');
@@ -874,7 +874,7 @@ describe('Topic\'s', () => {
 				done();
 			});
 		});
-	
+
 		it('should not do anything if topics are not pinned', (done) => {
 			socketTopics.orderPinnedTopics({ uid: adminUid }, { tid: tid3, order: 1 }, (err) => {
 				assert.ifError(err);
@@ -885,13 +885,13 @@ describe('Topic\'s', () => {
 				});
 			});
 		});
-	
+
 		it('should order pinned topics correctly', (done) => {
 			db.getSortedSetRevRange(`cid:${topic.categoryId}:tids:pinned`, 0, -1, (err, pinnedTids) => {
 				assert.ifError(err);
 				assert.equal(pinnedTids[0], tid2); // Expect tid2 to be first
 				assert.equal(pinnedTids[1], tid1); // Expect tid1 to be second
-				
+
 				socketTopics.orderPinnedTopics({ uid: adminUid }, { tid: tid1, order: 0 }, (err) => {
 					assert.ifError(err);
 					db.getSortedSetRevRange(`cid:${topic.categoryId}:tids:pinned`, 0, -1, (err, newPinnedTids) => {
@@ -903,7 +903,7 @@ describe('Topic\'s', () => {
 				});
 			});
 		});
-	
+
 		// Additional test cases for edge handling
 		it('should handle ordering with non-existent pinned topics gracefully', (done) => {
 			socketTopics.orderPinnedTopics({ uid: adminUid }, { tid: 9999, order: 0 }, (err) => {
@@ -911,7 +911,7 @@ describe('Topic\'s', () => {
 				done();
 			});
 		});
-	
+
 		it('should maintain the order when reordering the same topic', (done) => {
 			socketTopics.orderPinnedTopics({ uid: adminUid }, { tid: tid1, order: 1 }, (err) => {
 				assert.ifError(err);
@@ -924,7 +924,7 @@ describe('Topic\'s', () => {
 				});
 			});
 		});
-	
+
 		it('should gracefully handle empty pinned topics list', async () => {
 			// Unpin all topics and attempt to reorder
 			await topics.tools.unpin(tid1, adminUid);


### PR DESCRIPTION
Added logic for ensuring that pinned posts maintain their position at the top of the topics list regardless of other filters and sorts applied.

Made edits to **src/topics/index.js,** added more tests to existing **test/topics.js**
Resolves issue #13 

SPRINT 1 NOTE: This will be left open; due to dependencies on other group members' incomplete work this sprint, I was unable to test this with npm lin/test as well as the additional test cases I added to the test suite. Testing and further revisions will continue in Sprint 2, however this issue may be reassigned to another group member.

**SPRINT 2 UPDATE (@Alanna-Cao):**
This issue was reassigned to @DhanyaShah to complete during Sprint 2 once the issues with the backend in #12 are resolved. This decision was made in order to allow other group members to move forward with other user stories we planned to implement in Sprint 2.

**SPRINT 2 UPDATE (@DhanyaShah ):**
Persistence of pin posts logic was manually added to pin-backend branch, tests were not used and instead rewritten. This PR can be closed now.
