### PR TITLE
Visibility Feature Frontend PR in Quicktheme Submodule Location

### DIFF
--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -1,6 +1,8 @@
 
 'use strict';
-
+// I made changes in quick start module. Specifically
+// I added to the partials a file called composer-formatting.tpl
+// This file creates the viewed by UI component and its dropdown
 const _ = require('lodash');
 
 const db = require('../database');


### PR DESCRIPTION
A button was added to allow users to choose who can view the post such as moderators, admins, or all users when they post it.  The changes were also made in the front-end quickstart theme repository for users to be able to see the visibility button. 
Changes made in this file: /node_modules/nodebb-theme-quickstart/templates/partials/composer-formatting.tpl
This resolves #18

To see more information regarding this PR, please see below. 
The changes were made and merged to the front-end module here: https://github.com/sschauk/nodebb-theme-quickstart/pull/4 (https://github.com/sschauk/nodebb-theme-quickstart/pull/4)